### PR TITLE
faster normalize after multiplication (feature-gated)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
+[features]
+experimental-normalize = []
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 serde_cbor = "0.10.1"
 

--- a/benches/mul.rs
+++ b/benches/mul.rs
@@ -1,0 +1,15 @@
+#![feature(test)]
+
+extern crate test;
+use test::Bencher;
+use gmorph::*;
+
+#[bench]
+fn bench_mul(b: &mut Bencher) {
+    let key_pair = KeyPair::new();
+    let eone = Enc::encrypt(&key_pair, 1);
+
+    b.iter(|| {
+        test::black_box((1..1000).fold(eone, |old, new| old * eone));
+    })
+}

--- a/benches/mul.rs
+++ b/benches/mul.rs
@@ -1,8 +1,8 @@
 #![feature(test)]
 
 extern crate test;
-use test::Bencher;
 use gmorph::*;
+use test::Bencher;
 
 #[bench]
 fn bench_mul(b: &mut Bencher) {

--- a/src/algebra/m231.rs
+++ b/src/algebra/m231.rs
@@ -86,12 +86,12 @@ fn normalize_u64(mut v: u64) -> u32 {
 }
 
 #[inline]
-// should work for an argument of the form a * b where a,b < MODULUS
+// should work for arguments up to (MODULUS-1)*(MODULUS-1)
+// which is the case for products of the form a * b where a,b < MODULUS
 fn normalize_product(mut v: u64) -> u32 {
     v = (v >> 31) + (v & MODULUSU64);
-    if v >= MODULUSU64 {
-        v -= MODULUSU64;
-    }
+    v = (v >> 31) + (v & MODULUSU64); // sic!
+
     v as u32
 }
 

--- a/src/algebra/m231.rs
+++ b/src/algebra/m231.rs
@@ -120,15 +120,14 @@ impl AddAssign for Mod231 {
     }
 }
 
-
 impl Mul for Mod231 {
     type Output = Self;
 
-#[cfg(not(feature = "experimental-normalize"))]
+    #[cfg(not(feature = "experimental-normalize"))]
     fn mul(self, other: Self) -> Self::Output {
         Self(normalize_u64(self.0 as u64 * other.0 as u64))
     }
-#[cfg(feature = "experimental-normalize")]
+    #[cfg(feature = "experimental-normalize")]
     fn mul(self, other: Self) -> Self::Output {
         Self(normalize_product(self.0 as u64 * other.0 as u64))
     }

--- a/src/algebra/m231.rs
+++ b/src/algebra/m231.rs
@@ -86,6 +86,16 @@ fn normalize_u64(mut v: u64) -> u32 {
 }
 
 #[inline]
+// should work for an argument of the form a * b where a,b < MODULUS
+fn normalize_product(mut v: u64) -> u32 {
+    v = (v >> 31) + (v & MODULUSU64);
+    if v >= MODULUSU64 {
+        v -= MODULUSU64;
+    }
+    v as u32
+}
+
+#[inline]
 fn normalize(x: u32) -> u32 {
     modulo(x)
 }
@@ -110,11 +120,17 @@ impl AddAssign for Mod231 {
     }
 }
 
+
 impl Mul for Mod231 {
     type Output = Self;
 
+#[cfg(not(feature = "experimental-normalize"))]
     fn mul(self, other: Self) -> Self::Output {
         Self(normalize_u64(self.0 as u64 * other.0 as u64))
+    }
+#[cfg(feature = "experimental-normalize")]
+    fn mul(self, other: Self) -> Self::Output {
+        Self(normalize_product(self.0 as u64 * other.0 as u64))
     }
 }
 
@@ -226,7 +242,22 @@ mod tests {
 
     #[quickcheck]
     fn prop_normalize(x: u32) -> bool {
-        normalize(x) == ((x % MODULUS) + MODULUS) % MODULUS
+        normalize(x) == (x % MODULUS)
+    }
+
+    #[quickcheck]
+    fn prop_normalize_u64(x: u64) -> bool {
+        normalize_u64(x) == (x % MODULUSU64) as u32
+    }
+
+    #[quickcheck]
+    fn prop_normalize_product(a: u32, b: u32) -> TestResult {
+        if a >= MODULUS || b >= MODULUS {
+            return TestResult::discard();
+        }
+        let product = a as u64 * b as u64;
+        let prop = normalize_product(product) == (product % MODULUSU64) as u32;
+        TestResult::from_bool(prop)
     }
 
     #[quickcheck]


### PR DESCRIPTION
Currently, our modular multiplication, to avoid costly division, involves bit operations followed by subtraction in a loop. This PR replaces the loop by another round of bitwise operations.

While this is not a correct modulo operation in general, it should work for arguments up to `(MODULUS-1)*(MODULUS-1)`

The experimental implementation is  behind the `experimental-normalize` feature. To enable it use

```
cargo build --release  --features "experimental-normalize"
```

This PR also includes a multiplication benchmark that can be run via

```
cargo +nightly bench bench_mul --features "experimental-normalize"
```

(requires Rust nightly).