### PR TITLE
Use official nalgebra repo since rustsim/nalgebra#648 landed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 num-traits = "0.2"
-nalgebra = { git = "https://github.com/kubkon/nalgebra.git", branch = "noncommutative", features = ["serde-serialize"] }
+nalgebra = { git = "https://github.com/rustsim/nalgebra.git", rev = "d09aa50", features = ["serde-serialize"] }
 alga = "0.9"
 alga_derive = "0.9"
 modinverse = "0.1"


### PR DESCRIPTION
This commit updates the `nalgebra` dependency to the official git repo with our patch for noncommutative operations applied. We still have to rely on a git dependency for now which precludes us from publishing `gmorph` to `crates.io` but I suspect it shouldn't be too long for the merged changes in `nalgebra` to make it to an officially numbered version on `crates.io`.